### PR TITLE
Introduces initial database schema for social media platform

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,8 +1,132 @@
+generator client {
+    provider = "prisma-client-js"
+}
+
 datasource db {
     provider = "postgresql"
     url      = env("DATABASE_URL")
 }
 
-generator client {
-    provider = "prisma-client-js"
+model User {
+    id        String   @id @default(cuid())
+    name      String
+    email     String   @unique
+    avatarUrl String?
+    role      Role     @default(USER)
+    createdAt DateTime @default(now())
+    updatedAt DateTime @updatedAt
+
+    accounts    Account[]
+    posts       PostAuthor[] // posts authored (many-to-many)
+    likes       Like[]
+    comments    Comment[]
+    reports     Report[]
+    followers   Follow[]              @relation("UserFollowers")
+    following   Follow[]              @relation("UserFollowing")
+    leaderboard LeaderboardSnapshot[]
+}
+
+model Account {
+    id                String  @id @default(cuid())
+    userId            String
+    provider          String
+    providerAccountId String
+    accessToken       String?
+    refreshToken      String?
+    expiresAt         Int?
+
+    user User @relation(fields: [userId], references: [id])
+
+    @@unique([provider, providerAccountId])
+}
+
+model Post {
+    id          String   @id @default(cuid())
+    title       String
+    description String
+    previewUrl  String?
+    createdAt   DateTime @default(now())
+    updatedAt   DateTime @updatedAt
+
+    authors     PostAuthor[]
+    likes       Like[]
+    comments    Comment[]
+    reports     Report[]
+    leaderboard LeaderboardSnapshot[]
+}
+
+model PostAuthor {
+    id     String @id @default(cuid())
+    userId String
+    postId String
+
+    user User @relation(fields: [userId], references: [id])
+    post Post @relation(fields: [postId], references: [id])
+
+    @@unique([userId, postId])
+}
+
+model Like {
+    id        String   @id @default(cuid())
+    userId    String
+    postId    String
+    createdAt DateTime @default(now())
+
+    user User @relation(fields: [userId], references: [id])
+    post Post @relation(fields: [postId], references: [id])
+
+    @@unique([userId, postId])
+}
+
+model Comment {
+    id        String   @id @default(cuid())
+    userId    String
+    postId    String
+    content   String
+    createdAt DateTime @default(now())
+    updatedAt DateTime @updatedAt
+
+    user User @relation(fields: [userId], references: [id])
+    post Post @relation(fields: [postId], references: [id])
+}
+
+model Report {
+    id        String   @id @default(cuid())
+    userId    String
+    postId    String
+    reason    String
+    createdAt DateTime @default(now())
+
+    user User @relation(fields: [userId], references: [id])
+    post Post @relation(fields: [postId], references: [id])
+}
+
+model Follow {
+    id          String   @id @default(cuid())
+    followerId  String
+    followingId String
+    createdAt   DateTime @default(now())
+
+    follower  User @relation("UserFollowers", fields: [followerId], references: [id])
+    following User @relation("UserFollowing", fields: [followingId], references: [id])
+
+    @@unique([followerId, followingId])
+}
+
+model LeaderboardSnapshot {
+    id        String   @id @default(cuid())
+    month     String // e.g., "2025-09"
+    userId    String
+    postId    String?
+    score     Int
+    rank      Int
+    createdAt DateTime @default(now())
+
+    user User  @relation(fields: [userId], references: [id])
+    post Post? @relation(fields: [postId], references: [id])
+}
+
+enum Role {
+    USER
+    MODERATOR
 }


### PR DESCRIPTION
This commit updates the Prisma schema to include models for users, accounts, posts, likes, comments, reports, and followers, enabling a robust database structure for a social media platform.
It introduces relationships between models, such as many-to-many relationships between users and posts, and adds fields for various data, including user roles and post rankings.
The changes improve data organization and facilitate queries, ultimately enhancing the platform's overall functionality.